### PR TITLE
Fix the batch problem ( has no method slice )

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -51,6 +51,10 @@ var EmailTemplate = function(templateDirectory, defaults, done) {
       bufferType = that.bufferType
     }
 
+    if (typeof html === 'function') { 
+      callback = html;
+      html     = that.html;
+    }
     if (!html) html = that.html
     if (!text) text = that.text
     if (!stylesheet) stylesheet = that.stylesheet
@@ -58,7 +62,7 @@ var EmailTemplate = function(templateDirectory, defaults, done) {
     html = ejs.render(html, locals);
     text = (text) ? ejs.render(text, locals) : '';
     if (stylesheet) html = juice(html, stylesheet);
-    if (typeof html === 'function') callback = html;
+    
 
     // return a compressed buffer
     if (isBuffer) {


### PR DESCRIPTION
You can't pass to ejs.render() a function so if html is a function ( probably in batch mode ) then we set the html to that.html before calling ejs.render.
