### PR TITLE
Updated Juice reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   , "main": "lib/main.js"
   , "dependencies": {
         "ejs": "0.8.3"
-      , "juice": "https://github.com/niftylettuce/juice/tarball/master"
+      , "juice": "0.3.0"
       , "async": "0.1.22"
       , "underscore": "1.3.3"
   }


### PR DESCRIPTION
-Replaces github ref with newer NPM version (0.3.0)
-Due to AWOL mootools-slickparser NPM package [Issue 31](https://github.com/niftylettuce/node-email-templates/issues/29)
