### PR TITLE
Added support for additional template engines

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,7 +19,6 @@
   ],
 
   "node" : true,
-  "es5" : true,
   "browser" : true,
   "jquery": true,
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -13,10 +13,11 @@
 var path  = require('path')
   , fs    = require('fs')
   , async = require('async')
-  , ejs   = require('ejs')
   , juice = require('juice')
+  , glob  = require('glob')
   , zlib  = require('zlib')
   , _     = require('underscore')
+  , tm    = require('./templateManager')
 
 var validBufferTypes = [ 'deflate', 'deflateRaw', 'gzip' ]
 
@@ -59,11 +60,16 @@ var EmailTemplate = function(templateDirectory, defaults, done) {
     if (!text) text = that.text
     if (!stylesheet) stylesheet = that.stylesheet
     locals = _.defaults(locals, (typeof defaults === 'object') ? defaults : {});
-    locals.filename = path.join(templatePath, 'html.ejs');
-    html = ejs.render(html, locals);
-    locals.filename = path.join(templatePath, 'text.ejs');
-    text = (text) ? ejs.render(text, locals) : '';
+
+    locals.filename = glob.sync(templatePath + '/html*')[0];
+    locals.engine = path.extname(locals.filename);
+    html = tm(locals.engine).render(html, locals);
+    
+    locals.filename = glob.sync(templatePath + '/text*')[0];
+    locals.engine = path.extname(locals.filename);
+    text = (text) ? tm(locals.engine).render(text, locals) : '';
     if (stylesheet) html = juice(html, stylesheet);
+    
 
     // return a compressed buffer
     if (isBuffer) {
@@ -151,7 +157,8 @@ var EmailTemplate = function(templateDirectory, defaults, done) {
           return callback(templatePath + ' is not a valid directory path');
 
         // Ensure that at least the html.ejs file exists inside
-        that.html = path.join(templatePath, 'html.ejs');
+        that.html = glob.sync(templatePath + '/html*')[0];
+        //that.html = path.join(templatePath, 'html.ejs');
         fs.stat(that.html, function(err, stats) {
 
           if (err) return callback(err);
@@ -167,8 +174,8 @@ var EmailTemplate = function(templateDirectory, defaults, done) {
             else that.html = data;
 
             // Set asset paths
-            that.text = path.join(templatePath, 'text.ejs');
-            that.stylesheet = path.join(templatePath, 'style.css');
+            that.text = glob.sync(templatePath + '/text*')[0] || '';
+            that.stylesheet = glob.sync(templatePath + '/style*')[0] || '';
 
             async.map([that.text, that.stylesheet], checkExists, function(err, results) {
 

--- a/lib/templateManager.js
+++ b/lib/templateManager.js
@@ -1,0 +1,35 @@
+/** 
+ * Small utility module for compling HTML templates or pre-processed CSS.
+ * 
+ * @author: [@jasonsims]('https://github.com/jasonsims') 
+ */
+
+var ejs        = require('ejs')
+  , jade       = require('jade')
+  , swig       = require('swig')
+  , handlebars = require('handlebars')
+
+module.exports = function(engine) {
+  this.engine = engine
+  this.engineMap = {
+    // HTML Template engines.
+    '.jade'       : { render: jade.render },
+    '.ejs'        : { render: ejs.render },
+    '.swig'       : { render: renderSwig },
+    '.hbs'        : { render: renderHandlebars },
+    '.handlebars' : { render: renderHandlebars }
+  }
+  
+  // Wrap all compile functions so every processing engine supports
+  //  execution as .render(source, locals).
+  function renderSwig(source, locals) {
+    return swig.render(source, {'locals': locals})
+  }
+
+  function renderHandlebars(source, locals) {
+    var template = handlebars.compile(source);
+    return template(locals);
+  }
+  
+  return this.engineMap[this.engine];
+};

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
       , "async": "0.1.22"
       , "underscore": "1.3.3"
       , "combined-stream": "~0.0.4"
+      , "swig": "~1.3.2"
+      , "jade": "~1.1.5"
+      , "handlebars": "~1.3.0"
+      , "glob": "~3.2.8"
   }
   , "devDependencies": {
         "nodemailer": "0.3.27"


### PR DESCRIPTION
I moved template processing out to templateManager.js which knows how to process the template string based on the file extension. Currently it supports ejs, handlebars, swig, and jade. If there are any I missed let me know. When I get more time I can extend this to also process pre-processed CSS like less or styl.
