### PR TITLE
Issue #50 quick fix - append templateName to locals.templatePath

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -61,7 +61,7 @@ var EmailTemplate = function(templateDirectory, defaults, done) {
     if (!text) text = that.text
     if (!stylesheet) stylesheet = that.stylesheet
     locals = _.defaults(locals, (typeof defaults === 'object') ? defaults : {});
-    locals.templatePath = templatePath
+    locals.templatePath = that.templatePath
 
     // Configure options for template and stylesheet files.
     var htmlOpts = { source: html, locals: locals }
@@ -157,7 +157,7 @@ var EmailTemplate = function(templateDirectory, defaults, done) {
       if (templateName === undefined) return callback('templateName was not defined');
 
       // Set the full path to the template
-      var templatePath = path.join(templateDirectory, templateName);
+      var templatePath = that.templatePath = path.join(templateDirectory, templateName);
 
       // Ensure the `templateName` is a valid directory path
       fs.stat(templatePath, function(err, stats) {


### PR DESCRIPTION
Here's a quick fix for [Issue #50](https://github.com/niftylettuce/node-email-templates/issues/50), where `locals.templatePath` is incomplete because it's missing the `templateName` therefore `templateManager.render()` does not know which engine to use. With this fix Nodemailer batch emails are now properly being rendered by the template engine.
