### PR TITLE
Bugfix: Template information not stored in correct scope

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -28,7 +28,7 @@ var EmailTemplate = function(templateDirectory, defaults, done) {
 
   var that = this;
 
-  this.render = function(scopeInfo, locals, templatePath, html, text, stylesheet, bufferType, callback) {
+  this.render = function(locals, templatePath, html, text, stylesheet, bufferType, callback) {
     // Check if `bufferType` is a function (callback), or string
     var isBuffer = false
     if (typeof bufferType === 'function') {
@@ -42,22 +42,22 @@ var EmailTemplate = function(templateDirectory, defaults, done) {
       }
     }
 
-    // Check if `scopeInfo.bufferType` is not an empty string, so we'll use the
+    // Check if `bufferType` is not an empty string, so we'll use the
     // global bufferType instead.
-    if (scopeInfo.bufferType !== '') {
+    if (this.bufferType !== '') {
       isBuffer = true
-      bufferType = scopeInfo.bufferType
+      bufferType = this.bufferType
     }
 
     if (typeof html === 'function') {
       callback = html;
-      html     = scopeInfo.html;
+      html     = this.html;
     }
-    if (!html) html = scopeInfo.html
-    if (!text) text = scopeInfo.text
-    if (!stylesheet) stylesheet = scopeInfo.stylesheet
+    if (!html) html = this.html
+    if (!text) text = this.text
+    if (!stylesheet) stylesheet = this.stylesheet
     locals = _.defaults(locals, (typeof defaults === 'object') ? defaults : {});
-    locals.templatePath = scopeInfo.templatePath
+    locals.templatePath = this.templatePath
 
     // Configure options for template and stylesheet files.
     var htmlOpts = { source: html, locals: locals }
@@ -105,12 +105,12 @@ var EmailTemplate = function(templateDirectory, defaults, done) {
 
     done(null, function(templateName, locals, bufferType, callback) {
       var scopeInfo = {
-        'html': '',
-        'text': '',
-        'bufferType': '',
+        'templatePath': '',
         'stylesheet': '',
-        'templatePath': ''
-	  };
+        'text': '',
+        'html': '',
+        'bufferType':'' 
+      };
 
       // Check if `bufferType` is a function (callback), or string
       var isBuffer = false
@@ -146,12 +146,12 @@ var EmailTemplate = function(templateDirectory, defaults, done) {
       var batchCheck = function() {
         if (batchEmail) {
           if (isBuffer) scopeInfo.bufferType = bufferType
-          return callback(null, that.render);
+          return callback(null, that.render.bind(scopeInfo));
         }
         if (isBuffer) {
-          that.render(scopeInfo, locals, templatePath, null, null, null, bufferType, callback)
+          that.render.call(scopeInfo, locals, templatePath, null, null, null, bufferType, callback);
         } else {
-          that.render(scopeInfo, locals, templatePath, null, null, null, callback)
+          that.render.call(scopeInfo, locals, templatePath, null, null, null, callback);
         }
       };
 


### PR DESCRIPTION
If EmailTemplate was used to render multiple different templates in rapid succession it would always use the last template called for every render. This update moves the non-static data into a scope object.
