### PR TITLE
Updated node-sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "glob": "^4.0.0",
     "stylus": "^0.45.1",
     "styl": "^0.2.7",
-    "node-sass": "^0.8.6",
+    "node-sass": "^0.9.3",
     "less": "^1.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
node-sass 0.8.6 fails with v0.11.13. Checking to see if upgrading node-sass breaks email-templates
