### PR TITLE
Added Dust Partials (Includes)

### DIFF
--- a/lib/templateManager.js
+++ b/lib/templateManager.js
@@ -15,9 +15,9 @@ var path       = require('path')
   , sass       = require('node-sass')
   , stylus     = require('stylus')
   , styl       = require('styl')
-  , async = require('async')
-  , fs    = require('fs')
-  , _     = require('underscore')
+  , async      = require('async')
+  , fs         = require('fs')
+  , _          = require('underscore')
 
 module.exports = {
   engineMap: {
@@ -28,7 +28,7 @@ module.exports = {
     '.hbs'        : renderHandlebars,
     '.handlebars' : renderHandlebars,
     '.emblem'     : renderEmblem,
-    '.dust' 	  : renderDust,
+    '.dust'       : renderDust,
     // CSS pre-processors
     '.less'       : renderLess,
     '.stylus'     : renderStylus,
@@ -71,15 +71,16 @@ function renderEmblem(source, locals, cb) {
   cb(null, template(locals))
 }
 function renderDust(source, locals, cb) {
-  var dm = path.join(path.basename(path.dirname(locals.filename)), path.basename(locals.filename, '.dust'));
-  if (!dust.cache[dm]) {
+  var baseName = path.join(path.basename(path.dirname(locals.filename)), 
+                           path.basename(locals.filename, '.dust'));
+  if (!dust.cache[baseName]) {
     // Recursive compile
-    dustReadPartial({source: source, file: locals.filename, name: dm}, function() {
-      dust.render(dm, locals, cb);
+    dustReadPartial({source: source, file: locals.filename, name: baseName}, function() {
+      dust.render(baseName, locals, cb);
     });
   } else {
     // Already compiled
-    dust.render(dm, locals, cb);
+    dust.render(baseName, locals, cb);
   }
 
   // Compile and find partials
@@ -97,7 +98,8 @@ function renderDust(source, locals, cb) {
   function dustPartial(file, cb) {
     var sources = [];
     var dir = path.dirname(file.file);
-    var partial_re = new RegExp(/\{\>['"](.*?)['"]\/\}/g);
+    // Match partial include (e.g. {>"../layout"/} or {>layout/})
+    var partial_re = new RegExp(/\{\>['"]?(.*?)['"]?\/\}/g);
     var match;
     while (match = partial_re.exec(file.source)) {
       sources.push({

--- a/test/templates/dust/html.dust
+++ b/test/templates/dust/html.dust
@@ -1,0 +1,1 @@
+{>partial/}{<content}<h1>{engine}</h1>{/content}

--- a/test/templates/dust/partial.dust
+++ b/test/templates/dust/partial.dust
@@ -1,0 +1,1 @@
+<h1>{item}</h1>{+content}content{/content}

--- a/test/testTemplateManager.js
+++ b/test/testTemplateManager.js
@@ -111,6 +111,21 @@ describe('Template manager', function() {
     })
   })
 
+  it('should render dust with partials', function(done) {
+    var opts = {
+      locals: {item: 'test'},
+      filename: path.join(__dirname, 'templates', 'dust', 'html.dust'),
+      source: '{>partial/}{<content}<h1>{engine}</h1>{/content}'
+    }
+
+    tm.render(opts, function(err, res) {
+      expect(err).to.be.null;
+      expect(res).to.equal('<h1>test</h1><h1>.dust</h1>');
+
+      done()
+    })
+  })
+
   it('should render less', function(done) {
     var opts = {
       locals   : {},


### PR DESCRIPTION
Will automatically include, name, and compile dust files. Naming is dynamic and includes part of the directory structure since there might be multiple "html.dust" files in different template directories. Compiled templates should also be saved in the dust cache if used by the same name.
