### PR TITLE
Template engines should be optional

### DIFF
--- a/lib/templateManager.js
+++ b/lib/templateManager.js
@@ -5,16 +5,6 @@
  */
 
 var path       = require('path')
-  , ejs        = require('ejs')
-  , jade       = require('jade')
-  , swig       = require('swig')
-  , handlebars = require('handlebars')
-  , emblem     = require('emblem')
-  , dust 	     = require('dustjs-linkedin')
-  , less       = require('less')
-  , sass       = require('node-sass')
-  , stylus     = require('stylus')
-  , styl       = require('styl')
 
 module.exports = {
   engineMap: {
@@ -25,7 +15,7 @@ module.exports = {
     '.hbs'        : renderHandlebars,
     '.handlebars' : renderHandlebars,
     '.emblem'     : renderEmblem,
-    '.dust' 	    : renderDust,
+    '.dust'       : renderDust,
     // CSS pre-processors
     '.less'       : renderLess,
     '.stylus'     : renderStylus,
@@ -48,32 +38,40 @@ module.exports = {
 
 // Wrap all compile functions so every processing engine supports
 // execution as .render(source, locals, cb).
-
 // HTML template engines
 function renderJade(source, locals, cb) {
+  var jade = require('jade')
   jade.render(source, locals, cb)
 }
 function renderEjs(source, locals, cb) {
+  var ejs = require('ejs')
   cb(null, ejs.render(source, locals))
 }
 function renderSwig(source, locals, cb) {
+  var swig = require('swig')
   cb(null, swig.render(source, {'locals': locals}))
 }
 function renderHandlebars(source, locals, cb) {
+  var handlebars = require('handlebars')
   var template = handlebars.compile(source);
   cb(null, template(locals))
 }
 function renderEmblem(source, locals, cb) {
+  var emblem = require('emblem')
+    , handlebars = require('handlebars')
+
   var template = emblem.compile(handlebars, source)
   cb(null, template(locals))
 }
 function renderDust(source, locals, cb) {
+  var dust = require('dustjs-linkedin')
   dust.loadSource(dust.compile(source, 'tmp'));
   dust.render('tmp', locals, cb);
 }
 
 // CSS pre-processors
 function renderLess(source, locals, cb) {
+  var less = require('less')
   var dir = path.dirname(locals.filename);
   var base = path.basename(locals.filename);
   var parser = new(less.Parser)({
@@ -87,15 +85,21 @@ function renderLess(source, locals, cb) {
   });
 }
 function renderStylus(source, locals, cb) {
+  var stylus = require('stylus')
+
   // Render stylus synchronously as it does not appear to handle asynchronous
   // calls properly when an error is generated.
   var css = stylus.render(source, locals)
   cb(null, css)
 }
 function renderStyl(source, locals, cb) {
+  var styl = require('styl')
+
   cb(null, styl(source, locals).toString())
 }
 function renderSass(source, locals, cb) {
+  var sass = require('node-sass')
+
   // Result handlers required by sass.
   function errorHandler(err) { cb(err) }
   function successHandler(css) { cb(null, css)}

--- a/package.json
+++ b/package.json
@@ -49,20 +49,10 @@
     "test": "./node_modules/.bin/mocha --reporter spec --ui bdd"
   },
   "dependencies": {
-    "ejs": "^1.0.0",
     "juice2": "^0.6.0",
     "async": "^0.9.0",
     "underscore": "^1.6.0",
-    "swig": "^1.3.2",
-    "jade": "^1.3.1",
-    "handlebars": "^1.3.0",
-    "emblem": "~0.3.16",
-    "dustjs-linkedin": "^2.4.0",
-    "glob": "^4.0.0",
-    "stylus": "^0.45.1",
-    "styl": "^0.2.7",
-    "node-sass": "^0.9.3",
-    "less": "^1.7.0"
+    "glob": "^4.0.0"
   },
   "devDependencies": {
     "nodemailer": "^0.3.44",
@@ -70,7 +60,17 @@
     "mocha": "^1.19.0",
     "chai": "^1.9.1",
     "mkdirp": "^0.3.5",
-    "rimraf": "^2.2.8"
+    "rimraf": "^2.2.8",
+    "ejs": "^1.0.0",
+    "swig": "^1.3.2",
+    "jade": "^1.3.1",
+    "handlebars": "^1.3.0",
+    "emblem": "~0.3.16",
+    "dustjs-linkedin": "^2.4.0",
+    "less": "^1.7.0",
+    "stylus": "^0.45.1",
+    "styl": "^0.2.7",
+    "node-sass": "^0.9.3"
   },
   "bugs": {
     "url": "https://github.com/niftylettuce/node-email-templates/issues/new"


### PR DESCRIPTION
Moves all the template engines to `devDependencies` in `package.json` so tests will continue to work, but package users won't have to install every supported engine.
