### PR TITLE
Support for consolidate.js

### DIFF
--- a/lib/templateManager.js
+++ b/lib/templateManager.js
@@ -4,18 +4,19 @@
  * @author: [@jasonsims]('https://github.com/jasonsims')
  */
 
-var path       = require('path')
+var path = require('path')
+  , cons = require('consolidate')
 
 module.exports = {
   engineMap: {
     // HTML Template engines
-    '.jade'       : renderJade,
-    '.ejs'        : renderEjs,
-    '.swig'       : renderSwig,
-    '.hbs'        : renderHandlebars,
-    '.handlebars' : renderHandlebars,
+    '.jade'       : cons.jade.render,
+    '.ejs'        : cons.ejs.render,
+    '.swig'       : cons.swig.render,
+    '.hbs'        : cons.handlebars.render,
+    '.handlebars' : cons.handlebars.render,
     '.emblem'     : renderEmblem,
-    '.dust'       : renderDust,
+    '.dust'       : cons.dust.render,
     // CSS pre-processors
     '.less'       : renderLess,
     '.stylus'     : renderStylus,
@@ -39,34 +40,12 @@ module.exports = {
 // Wrap all compile functions so every processing engine supports
 // execution as .render(source, locals, cb).
 // HTML template engines
-function renderJade(source, locals, cb) {
-  var jade = require('jade')
-  jade.render(source, locals, cb)
-}
-function renderEjs(source, locals, cb) {
-  var ejs = require('ejs')
-  cb(null, ejs.render(source, locals))
-}
-function renderSwig(source, locals, cb) {
-  var swig = require('swig')
-  cb(null, swig.render(source, {'locals': locals}))
-}
-function renderHandlebars(source, locals, cb) {
-  var handlebars = require('handlebars')
-  var template = handlebars.compile(source);
-  cb(null, template(locals))
-}
 function renderEmblem(source, locals, cb) {
   var emblem = require('emblem')
     , handlebars = require('handlebars')
 
   var template = emblem.compile(handlebars, source)
   cb(null, template(locals))
-}
-function renderDust(source, locals, cb) {
-  var dust = require('dustjs-linkedin')
-  dust.loadSource(dust.compile(source, 'tmp'));
-  dust.render('tmp', locals, cb);
 }
 
 // CSS pre-processors

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "juice2": "^0.6.0",
+    "consolidate": "^0.10.0",
     "async": "^0.9.0",
     "underscore": "^1.6.0",
     "glob": "^4.0.0"


### PR DESCRIPTION
As commented on #79 a great way to support multiple engines with partials/helpers is to use consolidate.js

This pull requests adds initial support for it.
