### PR TITLE
#395 renderAll bug fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -263,7 +263,6 @@ class Email {
         is.emptyStringOrWhitespace(message.subject)) &&
       (!is.string(message.text) || is.emptyStringOrWhitespace(message.text)) &&
       (!is.string(message.html) || is.emptyStringOrWhitespace(message.html)) &&
-      _.isArray(message.attachments) &&
       _.isEmpty(message.attachments)
     )
       throw new Error(


### PR DESCRIPTION
Remove _.isArray(messsage.attachments) condition when checking to throw error in renderAll().
_.isEmpty(message.attachments) will simply return false if message.attachments is not an object, collection, map, or set.
[lodash docs](https://lodash.com/docs/4.17.15#isEmpty)