### PR TITLE
Added option to pass juiceResources with render and renderAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,10 @@ If this asset is in another folder, then you will need to modify the default opt
 const email = new Email({
   // <https://github.com/Automattic/juice>
   juice: true,
+  // Override juice global settings <https://github.com/Automattic/juice#juicecodeblockss>
+  juiceSettings: {
+    tableElements: ['TABLE']
+  },
   juiceResources: {
     preserveImportant: true,
     webResources: {
@@ -309,6 +313,45 @@ The example above assumes you have the following directory structure (note that 
         ├── html.pug
         ├── text.pug
         └── subject.pug
+```
+
+The Promise for `email.render` resolves with a String (the HTML or text rendered).
+
+> If you need pass juiceResources in render function, with this option you don't need create Email instance every time
+
+```js
+const Email = require('email-templates');
+
+const email = new Email();
+
+email
+  .render({
+    path: 'mars/html',
+    juiceResources: {
+      preserveImportant: true,
+      webResources: {
+        // view folder path, it will get css from `mars/style.css`
+        relativeTo: path.resolve('mars')
+      }
+    }
+  }, {
+    name: 'Elon'
+  })
+  .then(console.log)
+  .catch(console.error);
+```
+
+The example above will be useful when you have structure like this, this will be useful when you have separate css file for every template
+
+```sh
+.
+├── app.js
+└── emails
+    └── mars
+        ├── html.pug
+        ├── text.pug
+        ├── subject.pug
+        └── style.css
 ```
 
 The Promise for `email.render` resolves with a String (the HTML or text rendered).

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ email
   .catch(console.error);
 ```
 
-The example above will be useful when you have structure like this, this will be useful when you have separate css file for every template
+The example above will be useful when you have a structure like this, this will be useful when you have a separate CSS file for every template
 
 ```sh
 .

--- a/src/index.js
+++ b/src/index.js
@@ -87,6 +87,10 @@ class Email {
         subjectPrefix: false,
         // <https://github.com/Automattic/juice>
         juice: true,
+        // Override juice global settings <https://github.com/Automattic/juice#juicecodeblockss>
+        juiceSettings: {
+          tableElements: ['TABLE']
+        },
         juiceResources: {
           preserveImportant: true,
           webResources: {
@@ -113,6 +117,11 @@ class Email {
     if (!_.isFunction(this.config.transport.sendMail))
       this.config.transport = nodemailer.createTransport(this.config.transport);
 
+    // Override juice global settings https://github.com/Automattic/juice#juicecodeblocks
+    if (_.isObject(this.config.juiceSettings)) {
+      _.forEach(this.config.juiceSettings, (key, value) => juice[key] = value);
+    }
+
     debug('transformed config %O', this.config);
 
     this.juiceResources = this.juiceResources.bind(this);
@@ -126,12 +135,20 @@ class Email {
 
   // shorthand use of `juiceResources` with the config
   // (mainly for custom renders like from a database)
-  juiceResources(html) {
-    return juiceResources(html, this.config.juiceResources);
+  juiceResources(html, juiceRenderResources = {}) {
+    const juiceR = _.merge(this.config.juiceResources, juiceRenderResources);
+    return juiceResources(html, juiceR);
   }
 
   // a simple helper function that gets the actual file path for the template
   async getTemplatePath(template) {
+    let juiceRenderResources = {};
+
+    if (_.isObject(template)) {
+      juiceRenderResources = template.juiceResources;
+      template = template.path;
+    }
+
     const [root, view] = path.isAbsolute(template)
       ? [path.dirname(template), path.basename(template)]
       : [this.config.views.root, template];
@@ -141,7 +158,7 @@ class Email {
       this.config.views.options.extension
     );
     const filePath = path.resolve(root, paths.rel);
-    return { filePath, paths };
+    return { filePath, paths, juiceRenderResources };
   }
 
   // returns true or false if a template exists
@@ -159,6 +176,14 @@ class Email {
   }
 
   async checkAndRender(type, template, locals) {
+
+    let juiceRenderResources = {};
+
+    if (_.isObject(template)) {
+      juiceRenderResources = template.juiceResources;
+      template = template.path;
+    }
+
     const str = this.config.getPath(type, template, locals);
     if (!this.config.customRender) {
       const exists = await this.templateExists(str);
@@ -168,7 +193,7 @@ class Email {
     return this.render(str, {
       ...locals,
       ...(type === 'html' ? {} : { pretty: false })
-    });
+    }, juiceRenderResources);
   }
 
   // promise version of consolidate's render
@@ -176,7 +201,7 @@ class Email {
   // <https://github.com/queckezz/koa-views>
   async render(view, locals = {}) {
     const { map, engineSource } = this.config.views.options;
-    const { filePath, paths } = await this.getTemplatePath(view);
+    const { filePath, paths, juiceRenderResources } = await this.getTemplatePath(view);
     if (paths.ext === 'html' && !map) {
       const res = await readFile(filePath, 'utf8');
       return res;
@@ -217,7 +242,7 @@ class Email {
     // google now supports media queries
     // https://developers.google.com/gmail/design/reference/supported_css
     if (!this.config.juice) return res;
-    const html = await this.juiceResources(res);
+    const html = await this.juiceResources(res, juiceRenderResources);
     return html;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,9 @@ class Email {
 
     // Override juice global settings https://github.com/Automattic/juice#juicecodeblocks
     if (_.isObject(this.config.juiceSettings)) {
-      _.forEach(this.config.juiceSettings, (key, value) => juice[key] = value);
+      _.forEach(this.config.juiceSettings, (key, value) => {
+        juice[key] = value;
+      });
     }
 
     debug('transformed config %O', this.config);
@@ -176,7 +178,6 @@ class Email {
   }
 
   async checkAndRender(type, template, locals) {
-
     let juiceRenderResources = {};
 
     if (_.isObject(template)) {
@@ -190,10 +191,14 @@ class Email {
       if (!exists) return;
     }
 
-    return this.render(str, {
-      ...locals,
-      ...(type === 'html' ? {} : { pretty: false })
-    }, juiceRenderResources);
+    return this.render(
+      str,
+      {
+        ...locals,
+        ...(type === 'html' ? {} : { pretty: false })
+      },
+      juiceRenderResources
+    );
   }
 
   // promise version of consolidate's render
@@ -201,7 +206,11 @@ class Email {
   // <https://github.com/queckezz/koa-views>
   async render(view, locals = {}) {
     const { map, engineSource } = this.config.views.options;
-    const { filePath, paths, juiceRenderResources } = await this.getTemplatePath(view);
+    const {
+      filePath,
+      paths,
+      juiceRenderResources
+    } = await this.getTemplatePath(view);
     if (paths.ext === 'html' && !map) {
       const res = await readFile(filePath, 'utf8');
       return res;


### PR DESCRIPTION

- Option to override juice global settings <https://github.com/Automattic/juice#juicecodeblockss>
- If you need pass `juiceResources` in render function, with this option you don't need create Email instance every time
```js
const Email = require('email-templates');
const email = new Email();
email
  .render({
    path: 'mars/html',
    juiceResources: {
      preserveImportant: true,
      webResources: {
        // view folder path, it will get css from `mars/style.css`
        relativeTo: path.resolve('mars')
      }
    }
  }, {
    name: 'Elon'
  })
  .then(console.log)
  .catch(console.error);
```

The example above will be useful when you have a structure like this, this will be useful when you have a separate CSS file for every template

```sh
.
├── app.js
└── emails
    └── mars
        ├── html.pug
        ├── text.pug
        ├── subject.pug
        └── style.css
```