### PR TITLE
Remove pify and @sindresorhus/is

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "juice": "^7.0.0",
     "lodash": "^4.17.20",
     "nodemailer": "^6.4.14",
-    "pify": "^5.0.0",
     "preview-email": "^2.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   ],
   "dependencies": {
     "@ladjs/i18n": "^6.0.5",
-    "@sindresorhus/is": "^4.0.0",
     "consolidate": "^0.16.0",
     "debug": "^4.2.0",
     "get-paths": "^0.0.7",

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ const consolidate = require('consolidate');
 const debug = require('debug')('email-templates');
 const getPaths = require('get-paths');
 const htmlToText = require('html-to-text');
-const is = require('@sindresorhus/is');
 const juice = require('juice');
 const nodemailer = require('nodemailer');
 const previewEmail = require('preview-email');
@@ -293,10 +292,9 @@ class Email {
     // throw an error that says at least one must be found
     // otherwise the email would be blank (defeats purpose of email-templates)
     if (
-      (!is.string(message.subject) ||
-        is.emptyStringOrWhitespace(message.subject)) &&
-      (!is.string(message.text) || is.emptyStringOrWhitespace(message.text)) &&
-      (!is.string(message.html) || is.emptyStringOrWhitespace(message.html)) &&
+      (!_.isString(message.subject) || _.isEmpty(_.trim(message.subject))) &&
+      (!_.isString(message.text) || _.isEmpty(_.trim(message.text))) &&
+      (!_.isString(message.html) || _.isEmpty(_.trim(message.html))) &&
       _.isEmpty(message.attachments)
     )
       throw new Error(

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const util = require('util');
 
 const I18N = require('@ladjs/i18n');
 const _ = require('lodash');
@@ -10,7 +11,6 @@ const htmlToText = require('html-to-text');
 const is = require('@sindresorhus/is');
 const juice = require('juice');
 const nodemailer = require('nodemailer');
-const pify = require('pify');
 const previewEmail = require('preview-email');
 
 // promise version of `juice.juiceResources`
@@ -24,8 +24,8 @@ const juiceResources = (html, options) => {
 };
 
 const env = (process.env.NODE_ENV || 'development').toLowerCase();
-const stat = pify(fs.stat);
-const readFile = pify(fs.readFile);
+const stat = util.promisify(fs.stat);
+const readFile = util.promisify(fs.readFile);
 
 class Email {
   constructor(config = {}) {
@@ -246,7 +246,7 @@ class Email {
       if (_.isString(locals.locale)) i18n.setLocale(locals.locale);
     }
 
-    const res = await pify(renderFn)(filePath, locals);
+    const res = await util.promisify(renderFn)(filePath, locals);
     // transform the html with juice using remote paths
     // google now supports media queries
     // https://developers.google.com/gmail/design/reference/supported_css

--- a/yarn.lock
+++ b/yarn.lock
@@ -1117,11 +1117,6 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
-"@sindresorhus/is@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.0.0.tgz#2ff674e9611b45b528896d820d3d7a812de2f0e4"
-  integrity sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==
-
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6474,11 +6474,6 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
-pify@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-5.0.0.tgz#1f5eca3f5e87ebec28cc6d54a0e4aaf00acc127f"
-  integrity sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==
-
 pkg-conf@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/pkg-conf/-/pkg-conf-3.1.0.tgz#d9f9c75ea1bae0e77938cde045b276dac7cc69ae"


### PR DESCRIPTION
- Removed `pify` in favour of node's `util.promisify` available since v8.
- Removed `@sindresorhus/is` in favour of `lodash`