### PR TITLE
Added support for sending emails headers along with a message.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -312,7 +312,7 @@ class Email {
       ...options
     };
 
-    let { template, message, locals } = options;
+    let { template, message, locals, headers } = options;
 
     const attachments =
       message.attachments || this.config.message.attachments || [];
@@ -350,6 +350,9 @@ class Email {
       this.config.transport = nodemailer.createTransport({
         jsonTransport: true
       });
+    }
+    if(headers){
+      message.headers = headers;
     }
 
     const res = await this.config.transport.sendMail(message);


### PR DESCRIPTION
Added support for sending [email headers](https://sendpulse.com/support/glossary/email-header#:~:text=The%20email%20header%20is%20a,always%20precedes%20the%20email%20body) along with a message.
For instance, one usage is to add  `unsubscribe-link` header which is one of the ways to avoid being tagged as spam and making unsubscribing from the mailing list easier.
It's described with more details in [this link](https://mailtrap.io/blog/list-unsubscribe-header/)