### PR TITLE
Fix deprecation warning: "Calling promisify on a function that returns a Promise is likely a mistake"

### DIFF
--- a/index.js
+++ b/index.js
@@ -251,7 +251,7 @@ class Email {
       if (locale !== locals.locale) i18n.setLocale(locals.locale);
     }
 
-    const res = await util.promisify(renderFn)(filePath, locals);
+    const res = await renderFn(filePath, locals);
     // transform the html with juice using remote paths
     // google now supports media queries
     // https://developers.google.com/gmail/design/reference/supported_css


### PR DESCRIPTION
Fixes https://github.com/forwardemail/email-templates/issues/462 

I tested this change locally in my project and it seems to work fine. However, I am not familiar enough with the codebase to understand potential side-effects with other configurations.