### PR TITLE
fix: upgrade juice package to version 11 to remove a DeprecationWarning (closes #467)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@ladjs/i18n": "^8.0.3",
     "get-paths": "^0.0.7",
     "html-to-text": "^9.0.5",
-    "juice": "^10.0.0",
+    "juice": "^11.0.0",
     "lodash": "^4.17.21",
     "nodemailer": "^6.9.14"
   },


### PR DESCRIPTION
Upgrade `juice` package to version 11 to remove the `DeprecationWarning: The punycode module is deprecated` warning 

fix #467


## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
